### PR TITLE
Fixed flash_all function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 setup(name='stupidArtnet',
       author='cpvalente',
-      version='1.1.0',
+      version='1.1.1',
       license='MIT',
       description='(Very) Simple implementation of the Art-Net protocol',
       long_description=long_description,

--- a/stupidArtnet/StupidArtnet.py
+++ b/stupidArtnet/StupidArtnet.py
@@ -11,7 +11,7 @@ NOTES
 import socket
 from threading import Timer
 from stupidArtnet.ArtnetUtils import shift_this, put_in_range
-
+from time import sleep
 
 class StupidArtnet():
 	"""(Very) simple implementation of Artnet."""
@@ -301,11 +301,15 @@ class StupidArtnet():
 		self.clear()
 		self.show()
 
-	def flash_all(self):
+	def flash_all(self, delay=None):
 		"""Sends 255's all across."""
 		packet = [255] * self.PACKET_SIZE
 		self.set(packet)
 		self.show()
+		# Blackout after delay
+		if delay:
+			sleep(delay)
+			self.blackout()
 
 
 if __name__ == '__main__':

--- a/stupidArtnet/StupidArtnet.py
+++ b/stupidArtnet/StupidArtnet.py
@@ -303,10 +303,7 @@ class StupidArtnet():
 
 	def flash_all(self):
 		"""Sends 255's all across."""
-		packet = bytearray(self.PACKET_SIZE)
-		[255 for i in packet]
-		# for i in range(self.PACKET_SIZE):
-		# 	packet[i] = 255
+		packet = [255] * self.PACKET_SIZE
 		self.set(packet)
 		self.show()
 


### PR DESCRIPTION
An empty bytearray was being set. Corrected it to a list of 255-s with length PACKET_SIZE.
In the second commit, I added another argument "delay" which can be passed to keep the channels 255 for the given time.