### PR TITLE
Allow setting source address

### DIFF
--- a/stupidArtnet/StupidArtnet.py
+++ b/stupidArtnet/StupidArtnet.py
@@ -20,7 +20,7 @@ class StupidArtnet():
     UDP_PORT = 6454
 
     def __init__(self, target_ip='127.0.0.1', universe=0, packet_size=512, fps=30,
-                 even_packet_size=True, broadcast=False):
+                 even_packet_size=True, broadcast=False, source_address=None):
         """Initializes Art-Net Client.
 
         Args:
@@ -56,6 +56,11 @@ class StupidArtnet():
         if broadcast:
             self.socket_client.setsockopt(
                 socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+
+        if source_address:
+            self.socket_client.setsockopt(
+                socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.socket_client.bind(source_address)
 
         # Timer
         self.fps = fps


### PR DESCRIPTION
I needed to set the source address to broadcast on a specific interface. This allowed me to do so, not sure if it's of use to anyone else but I thought I'd contribute in case you wanted it :)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added the ability to specify a `source_address` in the `StupidArtnet` class. This allows users to define a specific network interface for sending Art-Net packets, providing greater control over packet routing. The socket option `SO_REUSEADDR` is set when a source address is provided, enabling the reuse of socket addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->