### PR TITLE
Added the ability to send ArtSync message in the Art-Net protocol implementation.

### DIFF
--- a/.github/workflows/run tests.yml
+++ b/.github/workflows/run tests.yml
@@ -7,10 +7,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.10.12
+    - name: Set up Python 3.11.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10.12
+        python-version: 3.11.8
 
     - name: Run test
       run: python -m unittest discover --v

--- a/stupidArtnet/StupidArtnet.py
+++ b/stupidArtnet/StupidArtnet.py
@@ -159,8 +159,6 @@ class StupidArtnet():
         except socket.error as error:
             print(f"ERROR: Socket error with exception: {error}")
         finally:
-            self.sequence = (self.sequence + 1) % 256
-            
             
     def show(self):
         """Finally send data."""

--- a/stupidArtnet/StupidArtnet.py
+++ b/stupidArtnet/StupidArtnet.py
@@ -158,7 +158,7 @@ class StupidArtnet():
             self.socket_client.sendto(packet, (self.target_ip, self.UDP_PORT))
         except socket.error as error:
             print(f"ERROR: Socket error with exception: {error}")
-        finally:
+
             
     def show(self):
         """Finally send data."""


### PR DESCRIPTION
**Changes:**
- Implemented the send_artsync method, which sends an ArtSync message to Art-Net receiving devices.
- Added the artsync_header header to the StupidArtnet class for creating ArtSync messages.

**Purpose:**
Introducing the capability to send ArtSync messages enables synchronization of Art-Net receiving devices, which is essential for ensuring synchronized lighting effects on stage or in other environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Updated the StupidArtnet class to support creating and sending an ArtSync header, enhancing synchronization capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->