### PR TITLE
chore: specify major version

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.11.8
+    - name: Set up Python 3
       uses: actions/setup-python@v1
       with:
-        python-version: 3.11.8
+        python-version: 3
 
     - name: Run test
       run: python -m unittest discover --v


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the continuous integration configuration to leverage a broader Python 3 version, enhancing flexibility during builds and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->