### PR TITLE
Make the thread at the client start/stopable

### DIFF
--- a/stupidArtnet/StupidArtnet.py
+++ b/stupidArtnet/StupidArtnet.py
@@ -10,7 +10,7 @@ NOTES
 
 import socket
 from threading import Thread
-from time import sleep
+from time import sleep, time
 from stupidArtnet.ArtnetUtils import shift_this, put_in_range
 
 

--- a/stupidArtnet/StupidArtnet.py
+++ b/stupidArtnet/StupidArtnet.py
@@ -44,8 +44,6 @@ class StupidArtnet():
         self.if_sync = artsync
         self.net = 0
         self.running = False
-        self.fps = fps
-        self.frame_delay = 1.0 / fps
         self.packet_size = put_in_range(packet_size, 2, 512, even_packet_size)
         self.packet_header = bytearray()
         self.buffer = bytearray(self.packet_size)
@@ -74,7 +72,7 @@ class StupidArtnet():
 
         # Timer
         self.fps = fps
-        self.__clock = None
+        self.frame_delay = 1.0 / fps
 
         self.make_artdmx_header()
         


### PR DESCRIPTION
With the fix is it possible to start / stop the thread every time
without restarting the main program.

I used the threading module instead of the _thread module.
It is more convient to handle the threads than the _thread module.
It is also possible to use deamon threads and you can stop/exit the thread gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized background threading implementation for DMX sender operations.
  * Implemented consistent frame rate control for data transmission.
  * Enhanced start/stop lifecycle management with improved thread handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->